### PR TITLE
feat: API.Bible acknowledgement and scripture copyright in Terms of Service

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@
   <div
     class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16 border-t border-accent"
   >
-    <p>© 2025 Fast & Pray</p>
+    <p>© 2026 Fast & Pray</p>
     <div class="flex space-x-4">
       <a href="/privacy" class="hover:text-gray-300">Privacy Policy</a>
       <a href="/terms" class="hover:text-gray-300">Terms of Service</a>

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -117,6 +117,17 @@ import Layout from "../layouts/Layout.astro";
       </p>
     </dd>
     <dt class="font-bold">
+      <a href="https://scripture.api.bible/" class="text-accent hover:underline">API.Bible</a>
+      (American Bible Society)
+    </dt>
+    <dd class="mb-2">
+      <p>
+        For providing the New King James Version (NKJV) and King James Version
+        with Apocrypha (KJVAIC) Scripture texts free of charge to support the
+        reading of Holy Scripture among our users.
+      </p>
+    </dd>
+    <dt class="font-bold">
       Our Beta Testers and the Faithful of St. John Armenian Church
     </dt>
     <dd class="mb-2">

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -75,7 +75,7 @@ import Layout from "../layouts/Layout.astro";
     <dd class="mb-2">
       <p>
         For his unwavering support and encouragement of this initative and all
-        efforts strentgthen the Western Diocese of the Armenian Church.
+        efforts to strengthen the Western Diocese of the Armenian Church.
       </p>
     </dd>
     <dt class="font-bold">Bishop Daniel Findikyan</dt>

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -85,12 +85,6 @@ import Layout from "../layouts/Layout.astro";
         privided to give meaning and structure to this tool.
       </p>
     </dd>
-    <dt class="font-bold">Fr. Hovel Ohanyan</dt>
-    <dd class="mb-2">
-      <p>
-        For his invaluable work in translating the user interface into Armenian.
-      </p>
-    </dd>
     <dt class="font-bold">Tom Samuelian</dt>
     <dd class="mb-2">
       <p>
@@ -101,6 +95,12 @@ import Layout from "../layouts/Layout.astro";
     <dt class="font-bold">Rev. Dr. Archdeacon George A. Leylegian</dt>
     <dd class="mb-2">
       <p>For insightful discussions and for sharing his research findings.</p>
+    </dd>
+    <dt class="font-bold">Dn. Mikayel Margaryan</dt>
+    <dd class="mb-2">
+      <p>
+        For his invaluable work in translating the user interface into Armenian.
+      </p>
     </dd>
     <dt class="font-bold">Daily Worship</dt>
     <dd class="mb-2">

--- a/src/pages/terms.md
+++ b/src/pages/terms.md
@@ -7,7 +7,7 @@ title: Terms of Service
 
 # Terms of Service for Fast & Pray
 
-**Effective Date:** December 30, 2024
+**Effective Date:** February 12, 2026
 
 Welcome to Fast & Pray! These Terms of Service (“Terms”) govern your access to and use of our mobile application and related services (collectively, the “App”). By using the App, you agree to these Terms. If you do not agree, do not use the App.
 
@@ -35,6 +35,25 @@ You agree NOT to:
 ## 3. Intellectual Property
 - All content, design, and intellectual property rights in the App are owned by Fast & Pray or its licensors.
 - You may not copy, distribute, or create derivative works based on the App without prior written consent.
+
+### 3.1. Scripture Content
+Scripture text displayed in the App is provided by [API.Bible](https://scripture.api.bible/), a ministry of the American Bible Society, and is subject to the following terms:
+
+**New King James Version (NKJV)**
+Scripture quotations marked (NKJV) are taken from the New King James Version®. Copyright © 1982 by Thomas Nelson. Used by permission. All rights reserved. The NKJV text may not be quoted in any publication made available to the public by a Creative Commons license. The NKJV may not be translated into any other language. For more information, visit [thomasnelson.com](https://www.thomasnelson.com/).
+
+**King James Version with Apocrypha, American Edition (KJVAIC)**
+Scripture quotations marked (KJVAIC) are taken from the King James Version with Apocrypha, American Edition. The Holy Bible, King James Version is in the public domain.
+
+**Usage Restrictions**
+- Scripture text displayed in the App is for personal, non-commercial use only and is provided for the purpose of spiritual reading and devotion.
+- You may not copy, reproduce, distribute, or create derivative works from the Scripture text displayed in the App.
+- Scripture content is displayed exactly as provided by API.Bible and may not be modified, adapted, or altered in any way.
+- The Scripture text may not be used in connection with any product or service that is not in conformity with the standards and teachings of historic, orthodox Christianity.
+- Fast & Pray does not claim ownership of any Scripture text. All rights to the Scripture text are retained by the respective rights holders and publishers.
+
+**Fair Use Tracking**
+The App participates in API.Bible's Fair Use Management System (FUMS), which anonymously tracks Scripture usage to ensure compliance with publisher requirements. No personally identifiable information is shared with API.Bible through FUMS.
 
 ## 4. User-Generated Content
 - You may have the ability to post or share content on the App (e.g., prayer requests, comments).


### PR DESCRIPTION
## What we needed to do

API.Bible's Terms of Use require that we:
1. Display proper copyright notices for all Bible versions we use (NKJV is copyrighted by Thomas Nelson; KJVAIC/KJV is public domain)
2. Attribute API.Bible as the provider of Scripture text
3. Disclose our participation in FUMS (Fair Use Management System) to users
4. Ensure users have access to full copyright and usage restriction details

Our mobile app's Learn page shows a condensed copyright section with a note directing users to "visit fastandpray.app" for complete terms. The landing site's Terms of Service page is where those complete terms need to live.

## Why we needed to do it

Without these additions, we were missing two compliance requirements:
- **Section 5 (Copyright)** of the API.Bible Terms of Use requires full copyright notices to be accessible to users. The mobile app links users to fastandpray.app, but the landing site had no scripture copyright information.
- **Section 6c (Logo/Brand Identity)** — since we opted for plain text attribution rather than using the API.Bible logo (which requires prior written consent), we need visible acknowledgement of API.Bible as the scripture provider.

Additionally, as a good-faith acknowledgement, we wanted to recognize API.Bible/American Bible Society on our /team page alongside the other organizations that support Fast & Pray.

## What we did

### Team page (`src/pages/team.astro`)
- Added **API.Bible (American Bible Society)** to the Acknowledgments section, placed below the existing Catena Bible Team entry and above Our Beta Testers
- Description: "For providing the New King James Version (NKJV) and King James Version with Apocrypha (KJVAIC) Scripture texts free of charge to support the reading of Holy Scripture among our users."
- Linked "API.Bible" to https://scripture.api.bible/ using the site's accent color

### Terms of Service (`src/pages/terms.md`)
- Added **Section 3.1: Scripture Content** under the existing Intellectual Property section, containing:
  - NKJV copyright notice (Thomas Nelson, © 1982, with Creative Commons and translation restrictions)
  - KJVAIC public domain notice
  - Usage restrictions (non-commercial, no copying/reproduction, no modification, orthodoxy requirement, no ownership claim)
  - FUMS disclosure (anonymous tracking, no PII shared)
  - Links to thomasnelson.com and API.Bible
- Updated the **Effective Date** from December 30, 2024 to February 12, 2026

## Testing

1. **Team page**: Verified the new API.Bible acknowledgement entry appears in the correct position in the Acknowledgments list (after Catena Bible Team, before Beta Testers) with a hyperlink to scripture.api.bible.
2. **Terms of Service**: Verified Section 3.1 renders correctly under the existing Section 3, with properly formatted headings for NKJV, KJVAIC, Usage Restrictions, and Fair Use Tracking. Confirmed links to thomasnelson.com and API.Bible are present.
3. **Cross-repo consistency**: Confirmed the copyright text in the Terms of Service matches the condensed versions shown in the mobile app's Learn page (`bahk_react_native/locales/en.json`), ensuring users who tap "For complete terms of use, visit fastandpray.app" find the same information expanded here.