### PR TITLE
fix: `exclude` overrides TypeScript's default dependency exclusions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "node_modules", "bower_components"]
 }


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-config-0c1c23856a-6_29283cab28`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-config-0c1c23856a-6e0ca_9103714f57`: `exclude` overrides TypeScript's default dependency exclusions (medium)

## Changed Files

- `tsconfig.json`

## Validation

- none recorded

## Plan

Expanded TypeScript exclusions in `tsconfig.json` to restore the usual dependency-directory filtering and avoid pulling `node_modules` into program construction.

