### PR TITLE
fix: RSS route silently emits an invalid feed when `site` is not configured

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,20 +2,23 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 
 export async function GET(context) {
+  if (!context.site?.href) {
+    throw new Error('RSS feed requires `site` to be configured with an absolute URL.');
+  }
+
   const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
     (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
   );
   return rss({
     title: 'Fast & Pray Blog',
     description: 'News, reflections, and updates from the Fast & Pray team',
-    site: context.site?.href || '',
+    site: context.site.href,
     items: posts.map((post) => ({
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.pubDate,
-      link: `/blog/${post.slug}/`,
+      link: new URL(`/blog/${post.slug}/`, context.site).href,
     })),
   });
 }
-
 


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-dc26ea5c9c-_87c26bfef5`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-library-dc26ea5c9c-4f4b_cd0662be1a`: RSS route silently emits an invalid feed when `site` is not configured (medium)

## Changed Files

- `src/pages/rss.xml.js`

## Validation

- none recorded

## Plan

Updated the RSS route to fail fast when `context.site` is missing and to emit absolute post links when it is present.

