### PR TITLE
fix: Package has no automated validation entrypoint for release-time type/content checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "check": "astro sync && tsc --noEmit",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-dc26ea5c9c-_d651efa0aa`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-library-dc26ea5c9c-a270_481277a599`: Package has no automated validation entrypoint for release-time type/content checks (medium)

## Changed Files

- `package.json`

## Validation

- none recorded

## Plan

Added a dedicated `check` script in `package.json` that runs `astro sync` and `tsc --noEmit`, providing an automated validation entrypoint for Astro-generated types and TypeScript checks without introducing new dependencies.

