### PR TITLE
fix: Blog schema allows posts without descriptions, but the RSS route publishes that field directly

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -11,11 +11,10 @@ export async function GET(context) {
     site: context.site?.href || '',
     items: posts.map((post) => ({
       title: post.data.title,
-      description: post.data.description,
+      description: post.data.description ?? '',
       pubDate: post.data.pubDate,
       link: `/blog/${post.slug}/`,
     })),
   });
 }
-
 


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-f8bf0b65a1-_14627be15d`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-library-f8bf0b65a1-16de_7048795ea7`: Blog schema allows posts without descriptions, but the RSS route publishes that field directly (low)

## Changed Files

- `src/pages/rss.xml.js`

## Validation

- none recorded

## Plan

Normalized RSS item descriptions to an empty string when a blog post omits `description`, keeping feed output consistent with the content schema.

