### PR TITLE
fix: No automated test entrypoint covers the RSS route or content-schema integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "node --test"
   },
   "dependencies": {
     "@astrojs/netlify": "^6.0.1",

--- a/tests/rss.test.mjs
+++ b/tests/rss.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+const blogDir = path.join(repoRoot, 'src', 'content', 'blog');
+
+function run(command, args) {
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: { ...process.env, PUBLIC_SITE: 'https://example.com' },
+  });
+}
+
+test('RSS feed excludes drafts and emits newest published entries with absolute fields', async () => {
+  const publishedFixture = path.join(blogDir, 'rss-test-latest.md');
+  const draftFixture = path.join(blogDir, 'rss-test-draft.md');
+
+  writeFileSync(
+    publishedFixture,
+    `---
+title: "RSS Test Latest Post"
+description: "Published fixture description."
+pubDate: 2030-01-15
+tags: ["test"]
+draft: false
+---
+
+Published fixture body.
+`
+  );
+
+  writeFileSync(
+    draftFixture,
+    `---
+title: "RSS Test Draft Post"
+description: "Draft fixture description."
+pubDate: 2031-01-15
+tags: ["test"]
+draft: true
+---
+
+Draft fixture body.
+`
+  );
+
+  try {
+    run(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['run', 'build']);
+
+    const rssModulePath = pathToFileURL(
+      path.join(repoRoot, '.netlify', 'build', 'pages', 'rss.xml.astro.mjs')
+    ).href;
+    const rssModule = await import(`${rssModulePath}?t=${Date.now()}`);
+    const response = await rssModule.page().GET({ site: new URL('https://example.com') });
+    const xml = await response.text();
+
+    const itemTitles = [...xml.matchAll(/<item><title>([^<]+)<\/title>/g)].map((match) => match[1]);
+    assert.equal(itemTitles[0], 'RSS Test Latest Post');
+    assert.ok(!xml.includes('RSS Test Draft Post'));
+    assert.ok(xml.includes('<link>https://example.com/blog/rss-test-latest/</link>'));
+    assert.ok(xml.includes('<description>Published fixture description.</description>'));
+  } finally {
+    rmSync(publishedFixture, { force: true });
+    rmSync(draftFixture, { force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-f8bf0b65a1-_9d8c864cce`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-f8bf0b65a1-3c2f_efeab878ba`: No automated test entrypoint covers the RSS route or content-schema integration (low)

## Changed Files

- `package.json`
- `tests/rss.test.mjs`

## Validation

- none recorded

## Plan

Added a minimal Node test entrypoint and an RSS integration test that builds the site with temporary blog fixtures, then verifies draft exclusion, newest-first ordering, and absolute feed fields.

