### PR TITLE
ci: add type-check and test jobs to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: TypeScript and content type checking
+      run: npm run check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
## What

Adds a CI workflow that gates PRs on type checking and tests.

## Why

The repo previously had no CI — only Netlify deploy previews. PRs #32 and #35 added `check` and `test` scripts but nothing enforced them on PRs.

## Jobs

| Job | Command | What it validates |
|---|---|---|
| type-check | `npm run check` | Astro sync + `tsc --noEmit` |
| test | `npm test` | `node --test` (RSS feed test) |

Triggers on PR → main/develop and push → main/develop.