### PR TITLE
test: add Playwright interactive coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,31 @@ jobs:
       with:
         name: coverage-report
         path: coverage/
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Run Playwright tests
+      run: npm run test:e2e
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 coverage/
+playwright-report/
+test-results/
 
 # environment variables
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "astro": "^5.1.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vitest/coverage-v8": "^4.1.7",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
@@ -3441,6 +3442,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -10443,6 +10460,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/netlify": "^6.0.1",
@@ -20,6 +21,7 @@
     "astro": "^5.1.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitest/coverage-v8": "^4.1.7",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4321',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1',
+    url: 'http://127.0.0.1:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/pages/survey.astro
+++ b/src/pages/survey.astro
@@ -690,18 +690,25 @@ const followUpMappings = sections.flatMap((section) =>
   function validateCurrentSection(): boolean {
     if (!sectionFieldsets.length) return true;
     const currentSection = sectionFieldsets[currentSectionIndex];
-    if (!currentSection || currentSection.reportValidity()) {
-      const q19Options = currentSection?.querySelectorAll(`input[name="q19"]`) as
-        | NodeListOf<HTMLInputElement>
-        | undefined;
-      if (q19Options && q19Options.length > 0 && !Array.from(q19Options).some((option) => option.checked)) {
-        setStatus("Please select at least one option for practices before continuing.", "error");
-        q19Options[0].focus();
+    if (!currentSection) return true;
+
+    const requiredControls = Array.from(
+      currentSection.querySelectorAll("input[required], textarea[required], select[required]")
+    ) as Array<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+
+    for (const control of requiredControls) {
+      if (!control.reportValidity()) {
         return false;
       }
-      return true;
     }
-    return false;
+
+    const q19Options = currentSection.querySelectorAll(`input[name="q19"]`) as NodeListOf<HTMLInputElement>;
+    if (q19Options.length > 0 && !Array.from(q19Options).some((option) => option.checked)) {
+      setStatus("Please select at least one option for practices before continuing.", "error");
+      q19Options[0].focus();
+      return false;
+    }
+    return true;
   }
 
   function goToSection(nextIndex: number) {

--- a/tests/e2e/bible-studies.spec.ts
+++ b/tests/e2e/bible-studies.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('Bible study overview links to sessions and day navigation works', async ({ page }) => {
+  await page.goto('/bible-studies');
+
+  await expect(page.getByRole('heading', { name: 'Guided Bible Studies' })).toBeVisible();
+  await page.getByRole('link', { name: /Fast of Elijah/ }).click();
+
+  await expect(page.getByRole('heading', { name: 'Fast of Elijah' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+
+  await page.getByRole('link', { name: /The Spirit of Communion and Love/ }).click();
+
+  await expect(page.getByText('Fast of Elijah · Day 1 of 5')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'The Spirit of Communion and Love' })).toBeVisible();
+
+  await page.getByRole('link', { name: /Day 2: You Shall Have No Other Gods Before Me/ }).click();
+
+  await expect(page).toHaveURL(/\/bible-studies\/fast-of-elijah\/2\/$/);
+  await expect(page.getByText('Fast of Elijah · Day 2 of 5')).toBeVisible();
+  await expect(page.getByRole('link', { name: /Day 1: The Spirit of Communion and Love/ })).toBeVisible();
+});

--- a/tests/e2e/icon-library.spec.ts
+++ b/tests/e2e/icon-library.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+const icons = [
+  {
+    id: 101,
+    title: 'Nativity of Christ',
+    church_name: 'St. John Armenian Church',
+    tag_list: ['Nativity', 'Christ', 'Feast'],
+    thumbnail_url: '',
+    image: '',
+  },
+  {
+    id: 102,
+    title: 'St. Gregory the Illuminator',
+    church_name: 'Armenian Apostolic Church',
+    tag_list: ['Saints', 'Armenian'],
+    thumbnail_url: '',
+    image: '',
+  },
+];
+
+test('icon library loads, searches, and renders API results', async ({ page }) => {
+  let requestedSearch = '';
+
+  await page.route('https://api.fastandpray.app/api/icons/?**', async (route) => {
+    const url = new URL(route.request().url());
+    requestedSearch = url.searchParams.get('search') ?? '';
+
+    await route.fulfill({
+      json: {
+        count: icons.length,
+        next: null,
+        previous: null,
+        results: icons,
+      },
+    });
+  });
+
+  await page.goto('/icons');
+
+  await expect(page.getByRole('heading', { name: 'Fast & Pray Icon Library' })).toBeVisible();
+  await expect(page.getByText('2 icons in the library')).toBeVisible();
+  await expect(page.getByRole('link', { name: /Nativity of Christ/ })).toBeVisible();
+
+  await page.getByPlaceholder(/Search icons/).fill('Gregory');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  await expect.poll(() => requestedSearch).toBe('Gregory');
+  await expect(page.getByText('2 results for "Gregory"')).toBeVisible();
+  await expect(page.getByRole('link', { name: /St. Gregory the Illuminator/ })).toBeVisible();
+});
+
+test('AI match posts the prompt and renders confidence badges', async ({ page }) => {
+  let requestBody: unknown;
+
+  await page.route('https://api.fastandpray.app/api/icons/?**', async (route) => {
+    await route.fulfill({ json: { count: 0, next: null, previous: null, results: [] } });
+  });
+
+  await page.route('https://api.fastandpray.app/api/icons/match/', async (route) => {
+    requestBody = route.request().postDataJSON();
+
+    await route.fulfill({
+      json: {
+        matches: [
+          {
+            icon: icons[0],
+            confidence: 'high',
+          },
+        ],
+      },
+    });
+  });
+
+  await page.goto('/icons');
+  await page.getByPlaceholder(/Search icons/).fill('baby Jesus icon');
+  await page.getByRole('button', { name: /AI Match/ }).click();
+
+  await expect.poll(() => requestBody).toMatchObject({
+    prompt: 'baby Jesus icon',
+    return_format: 'full',
+    max_results: 9,
+  });
+  await expect(page.getByText('AI found 1 match for "baby Jesus icon"')).toBeVisible();
+  await expect(page.getByText('high')).toBeVisible();
+});

--- a/tests/e2e/survey.spec.ts
+++ b/tests/e2e/survey.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+test('survey validates required sections, reveals follow-ups, and submits payload', async ({ page }) => {
+  let submittedPayload: Record<string, string> | undefined;
+
+  await page.route('https://czpmtdcjogaueynyyioi.supabase.co/rest/v1/fast_pray_survey_responses', async (route) => {
+    submittedPayload = route.request().postDataJSON();
+    await route.fulfill({ status: 201, body: '' });
+  });
+
+  await page.goto('/survey');
+
+  await expect(page.getByRole('heading', { name: 'Fast & Pray Research Survey' })).toBeVisible();
+  await expect(page.getByText('Section 1 of 6')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next Section' }).click();
+  await expect(page.getByText('Section 1 of 6')).toBeVisible();
+
+  await page.getByLabel('Less than 1 month').check();
+  await page.getByLabel('Daily').check();
+  await page.getByLabel('Consistent but seeking deeper growth').check();
+  await page.getByLabel('Armenian Apostolic').check();
+  await page.getByRole('button', { name: 'Next Section' }).click();
+
+  await expect(page.getByText('Section 2 of 6')).toBeVisible();
+  await page.getByRole('radio', { name: 'A lot', exact: true }).check();
+  await expect(page.getByLabel('If yes, how?')).toBeVisible();
+  await page.getByLabel('If yes, how?').fill('It helped me understand fasting as prayer.');
+  await page.getByRole('button', { name: 'Next Section' }).click();
+
+  await expect(page.getByText('Section 3 of 6')).toBeVisible();
+  await page.getByLabel('It encourages me a lot').check();
+  await page.getByRole('button', { name: 'Next Section' }).click();
+
+  await expect(page.getByText('Section 4 of 6')).toBeVisible();
+  await page.locator('input[name="q18"][value="Yes"]').check();
+  await page.getByLabel('Keeping track of fast days').check();
+  await page.locator('input[name="q20"][value="Time"]').check();
+  await page.getByRole('button', { name: 'Next Section' }).click();
+
+  await expect(page.getByText('Section 5 of 6')).toBeVisible();
+  await page.getByLabel('Never').check();
+  await page.getByRole('button', { name: 'Next Section' }).click();
+
+  await expect(page.getByText('Section 6 of 6')).toBeVisible();
+  await page.getByLabel('Yes, anonymously').check();
+  await page.getByRole('button', { name: 'Submit Survey' }).click();
+
+  await expect(page.getByText('Thank you. Your survey has been submitted.')).toBeVisible();
+  expect(submittedPayload).toMatchObject({
+    q01: 'Less than 1 month',
+    q02: 'Daily',
+    q03: 'Consistent but seeking deeper growth',
+    q04: 'Armenian Apostolic',
+    q13: 'A lot\nFollow-up: It helped me understand fasting as prayer.',
+    q14: 'It encourages me a lot',
+    q18: 'Yes',
+    q19: 'Keeping track of fast days',
+    q20: 'Time',
+    q24: 'Never',
+    q27: 'Yes, anonymously',
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { getViteConfig } from 'astro/config';
 
 export default getViteConfig({
   test: {
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
     testTimeout: 90_000,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- add Playwright E2E config and CI job
- cover icon library keyword search and AI match with mocked API responses
- cover Bible study overview/session navigation
- cover survey wizard validation, follow-up reveal, and mocked Supabase submission
- fix survey section validation so required controls block advancing to the next section
- keep Vitest from collecting Playwright specs

## Verification
- npm run check
- npm test
- npm run test:coverage
- npm run test:e2e