### PR TITLE
fix: check script calls tsc without declaring TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "postcss": "^8.4.49",
         "postcss-cli": "^11.0.0",
         "tailwindcss": "^3.4.16",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postcss": "^8.4.49",
     "postcss-cli": "^11.0.0",
     "tailwindcss": "^3.4.16",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.7"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-config-7528cb5b98-a_597d8bafdf`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-config-7528cb5b98-ae166_09631b61dd`: check script calls tsc without declaring TypeScript (medium)

## Changed Files

- `package.json`
- `package-lock.json`

## Validation

- none recorded

## Plan

Added TypeScript as an explicit devDependency so the `check` script does not rely on a transitive `tsc` binary.

