### PR TITLE
Harden /readings against crawlers walking unbounded dates

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /readings/

--- a/src/pages/readings/[date].astro
+++ b/src/pages/readings/[date].astro
@@ -118,6 +118,7 @@ const nextDate = hasValidDate ? shiftDate(requestedDate, 1) : "";
 ---
 
 <Layout pageTitle={pageTitle}>
+  <meta name="robots" content="noindex, nofollow" slot="meta" />
   <section class="space-y-6">
     <header class="space-y-3">
       <h1 class="text-3xl font-bold">Daily Readings</h1>
@@ -127,10 +128,10 @@ const nextDate = hasValidDate ? shiftDate(requestedDate, 1) : "";
       </p>
       {hasValidDate && (
         <div class="flex gap-4 text-sm">
-          <a href={`/readings/${previousDate}`} class="text-accent hover:underline">
+          <a href={`/readings/${previousDate}`} rel="nofollow" class="text-accent hover:underline">
             Previous day
           </a>
-          <a href={`/readings/${nextDate}`} class="text-accent hover:underline">
+          <a href={`/readings/${nextDate}`} rel="nofollow" class="text-accent hover:underline">
             Next day
           </a>
         </div>

--- a/src/pages/readings/index.astro
+++ b/src/pages/readings/index.astro
@@ -28,6 +28,7 @@ const nextDay = shiftDate(today, +1);
 ---
 
 <Layout pageTitle="Daily Readings • Fast & Pray">
+  <meta name="robots" content="noindex, nofollow" slot="meta" />
   <div class="max-w-2xl mx-auto text-center">
     <!-- Hero -->
     <h1 class="text-3xl md:text-4xl font-bold text-[#3B0714] mb-4">
@@ -98,6 +99,7 @@ const nextDay = shiftDate(today, +1);
     <div class="flex justify-center gap-8 text-sm">
       <a
         href={`/readings/${prevDay}`}
+        rel="nofollow"
         class="text-accent hover:underline"
         aria-label="Previous day: {prevDay}"
       >
@@ -105,6 +107,7 @@ const nextDay = shiftDate(today, +1);
       </a>
       <a
         href={`/readings/${nextDay}`}
+        rel="nofollow"
         class="text-accent hover:underline"
         aria-label="Next day: {nextDay}"
       >


### PR DESCRIPTION
## Problem

The `/readings/[date]` and `/readings` pages render next/prev-day links with **no upper bound**, so a crawler can walk forward day-by-day. Each new uncached date triggers a backend scrape + a first-time API.Bible text fetch per reading, which recently nearly exhausted the monthly API.Bible request budget (~4,994/5,000).

## Change

Keep the next/prev links — they're good UX for real users — but stop crawlers from following them:

- **`public/robots.txt`** (new): `Disallow: /readings/` for all user-agents.
- **`noindex, nofollow` robots meta** on both readings pages, via `Layout.astro`'s `meta` slot.
- **`rel="nofollow"`** on the next/prev-day links in both `[date].astro` and `index.astro`.

With these, **compliant** crawlers won't index or walk the date links, and a real user clicking forward into a sourceless future date just sees the existing clean empty state. Hopefully no non-compliant crawlers eat up our API limits again before we can deprecate web-scraping.

## Testing

- `npm run build` succeeds; `robots.txt` is emitted to `dist/`.
- Readings pages are SSR (`prerender=false`); build compiles the `meta` slot and `rel` attributes without error.

## Notes

This is the crawl-vector fix. Backend defense-in-depth (negative-caching empty dates, a monthly new-retrieval cap) was scoped separately and is likely unnecessary given the planned deprecation of web-scraping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)