### PR TITLE
Cache /readings at the edge and share the Pacific date helpers

### DIFF
--- a/src/pages/readings/[date].astro
+++ b/src/pages/readings/[date].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import { getTodayInPacific, isValidDateSlug, shiftDate } from "../../utils/date";
 
 const apiBase = import.meta.env.PUBLIC_API_URL ?? "https://api.fastandpray.app";
 
@@ -25,15 +26,6 @@ type ReadingsResponse = {
 };
 
 const rawDate = Astro.params.date;
-
-function isValidDateSlug(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return false;
-  }
-
-  const parsed = new Date(`${value}T00:00:00Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
-}
 
 function formatReference(reading: Reading): string {
   const book = reading.book ?? "Reading";
@@ -62,14 +54,49 @@ function formatReference(reading: Reading): string {
   return `${book} ${startChapter}:${startVerse}-${endChapter}:${endVerse}`;
 }
 
-function shiftDate(value: string, days: number): string {
-  const parsed = new Date(`${value}T00:00:00Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
-}
-
 const requestedDate = typeof rawDate === "string" ? rawDate : "";
 const hasValidDate = isValidDateSlug(requestedDate);
+
+const today = getTodayInPacific();
+const isPastDate = hasValidDate && requestedDate < today;
+
+/**
+ * Cache at the edge so repeat hits never reach the Django origin.
+ *
+ * `Netlify-CDN-Cache-Control` governs the CDN; plain `Cache-Control` governs browsers.
+ * This matters beyond ordinary performance: an origin hit for a date with no stored text
+ * costs a paid API.Bible call, so serving crawlers and repeat visitors from cache is
+ * directly a spend control.
+ */
+function setCacheHeaders(kind: "past" | "current" | "invalid" | "error") {
+  if (kind === "error") {
+    // Never cache a backend outage — it would outlive the outage.
+    Astro.response.headers.set("Cache-Control", "no-store");
+    return;
+  }
+  if (kind === "invalid") {
+    // Deterministic and never touches the origin; cache it hard.
+    Astro.response.headers.set("Cache-Control", "public, max-age=3600");
+    Astro.response.headers.set("Netlify-CDN-Cache-Control", "public, s-maxage=86400");
+    return;
+  }
+  if (kind === "past") {
+    // A past day's readings no longer change.
+    Astro.response.headers.set("Cache-Control", "public, max-age=300");
+    Astro.response.headers.set(
+      "Netlify-CDN-Cache-Control",
+      "public, s-maxage=86400, stale-while-revalidate=604800",
+    );
+    return;
+  }
+  // Today and future: AI-generated context is produced asynchronously, so the first
+  // response for a date is incomplete. Keep the window short enough to pick it up.
+  Astro.response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+  Astro.response.headers.set(
+    "Netlify-CDN-Cache-Control",
+    "public, s-maxage=900, stale-while-revalidate=3600",
+  );
+}
 
 let payload: ReadingsResponse | null = null;
 let errorMessage: string | null = null;
@@ -77,6 +104,7 @@ let errorMessage: string | null = null;
 if (!hasValidDate) {
   Astro.response.status = 400;
   errorMessage = "Invalid date. Use /readings/YYYY-MM-DD.";
+  setCacheHeaders("invalid");
 } else {
   const endpoint = new URL(apiBase + "/api/readings/");
   endpoint.searchParams.set("date", requestedDate);
@@ -89,6 +117,7 @@ if (!hasValidDate) {
     if (!response.ok) {
       Astro.response.status = response.status;
       errorMessage = `Could not load readings for ${requestedDate} (HTTP ${response.status}).`;
+      setCacheHeaders("error");
     } else {
       const data: unknown = await response.json();
       if (
@@ -100,13 +129,16 @@ if (!hasValidDate) {
       ) {
         Astro.response.status = 502;
         errorMessage = "Readings service returned an unexpected format.";
+        setCacheHeaders("error");
       } else {
         payload = data as ReadingsResponse;
+        setCacheHeaders(isPastDate ? "past" : "current");
       }
     }
   } catch {
     Astro.response.status = 502;
     errorMessage = "Could not reach the readings service.";
+    setCacheHeaders("error");
   }
 }
 

--- a/src/pages/readings/index.astro
+++ b/src/pages/readings/index.astro
@@ -3,30 +3,16 @@ import Layout from "../../layouts/Layout.astro";
 import CtaButton from "../../components/CtaButton.astro";
 import PageHeader from "../../components/PageHeader.astro";
 
-function getTodayInPacific(): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Los_Angeles",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date());
-}
+import { getTodayInPacific, shiftDate } from "../../utils/date";
 
 const today = getTodayInPacific();
-
-function shiftDate(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T12:00:00-07:00");
-  d.setDate(d.getDate() + days);
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Los_Angeles",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(d);
-}
-
 const prevDay = shiftDate(today, -1);
 const nextDay = shiftDate(today, +1);
+
+// This page is "today"-relative, so it can be cached at the edge only briefly. Doing so
+// keeps repeat bot hits off the origin without letting the date go stale.
+Astro.response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+Astro.response.headers.set("Netlify-CDN-Cache-Control", "public, s-maxage=300");
 ---
 
 <Layout pageTitle="Daily Readings • Fast & Pray">

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,38 @@
+/**
+ * Date helpers for the readings pages.
+ *
+ * Everything is computed in America/Los_Angeles because the backend's liturgical day
+ * rolls over on Pacific time. Doing it in UTC drifts the "previous/next day" links by a
+ * day for anyone browsing in the evening Pacific.
+ */
+
+const PACIFIC = "America/Los_Angeles";
+
+const isoFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: PACIFIC,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** Today's date in Pacific time, as YYYY-MM-DD. */
+export function getTodayInPacific(): string {
+  return isoFormatter.format(new Date());
+}
+
+/** Shift a YYYY-MM-DD slug by *days*, staying in Pacific time. */
+export function shiftDate(dateStr: string, days: number): string {
+  // Midday anchor so a DST transition cannot push the result into the adjacent day.
+  const d = new Date(`${dateStr}T12:00:00-07:00`);
+  d.setDate(d.getDate() + days);
+  return isoFormatter.format(d);
+}
+
+/** True when *value* is a well-formed YYYY-MM-DD calendar date. */
+export function isValidDateSlug(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}


### PR DESCRIPTION
## Why

Every hit on `/readings/YYYY-MM-DD` is an SSR request that calls the Django readings API, and a date with no stored text costs a paid API.Bible call. `robots.txt` (#41) stops well-behaved crawlers, but bots that ignore it still reach the origin on every request — and spend was unchanged in the three weeks since that shipped. Caching at the CDN makes repeat hits free.

Pairs with surp-hovhannes/bahk#466, which bounds the spend on the backend side.

## Changes

**Edge caching** via `Netlify-CDN-Cache-Control` (governs the CDN; plain `Cache-Control` governs browsers):

| Case | `Cache-Control` | `Netlify-CDN-Cache-Control` |
|---|---|---|
| Past date, 200 | `public, max-age=300` | `public, s-maxage=86400, stale-while-revalidate=604800` |
| Today/future, 200 | `public, max-age=0, must-revalidate` | `public, s-maxage=900, stale-while-revalidate=3600` |
| Invalid slug, 400 | `public, max-age=3600` | `public, s-maxage=86400` |
| Backend error, 5xx | `no-store` | *(unset)* |

Past dates cache hard because their readings no longer change. Today/future stay short because AI-generated context is produced asynchronously, so the first response for a date is incomplete. Invalid slugs cache hard because they're deterministic and never touch the origin. Errors aren't cached at all — a cached 502 would outlive the outage.

**Shared date helpers** in `src/utils/date.ts`. `[date].astro` had its own UTC-based `shiftDate` while `index.astro` used Pacific, so the previous/next-day links disagreed by a day in the evening Pacific. Both now use the Pacific version — which also gives `[date].astro` the "is this a past date" check the cache policy needs.

## Verified

Ran the dev server against a local stub API (deliberately *not* production — that would spend real API.Bible calls) and confirmed each case emits the intended headers, including `no-store` on the error path with the stub killed. `noindex,nofollow` and `rel="nofollow"` from #41 are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)